### PR TITLE
Less needless cloning of the time_zone_designation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ use std::fmt;
 use std::fs::{self, File};
 use std::io::{self, Read};
 use std::num::TryFromIntError;
+use std::sync::Arc;
 use std::time::{SystemTime, SystemTimeError};
 
 use tz_file::TzFileError;
@@ -227,7 +228,7 @@ pub struct LocalTimeType {
     /// Daylight Saving Time indicator
     is_dst: bool,
     /// Time zone designation
-    time_zone_designation: String,
+    time_zone_designation: Arc<str>,
 }
 
 impl LocalTimeType {
@@ -253,7 +254,7 @@ impl LocalTimeType {
 
     /// Construct a local time type with the specified offset in seconds
     pub fn with_ut_offset(ut_offset: i32) -> Self {
-        Self { ut_offset, is_dst: false, time_zone_designation: "".to_owned() }
+        Self { ut_offset, is_dst: false, time_zone_designation: "".into() }
     }
 }
 
@@ -910,8 +911,8 @@ mod test {
         assert_eq!(*transition_rule_fixed.find_local_time_type(0)?, LocalTimeType::utc());
 
         let transition_rule_neg = TransitionRule::Alternate {
-            std: LocalTimeType { ut_offset: 0, is_dst: false, time_zone_designation: "".to_owned() },
-            dst: LocalTimeType { ut_offset: 0, is_dst: true, time_zone_designation: "".to_owned() },
+            std: LocalTimeType { ut_offset: 0, is_dst: false, time_zone_designation: "".into() },
+            dst: LocalTimeType { ut_offset: 0, is_dst: true, time_zone_designation: "".into() },
             dst_start: RuleDay::Julian0WithLeap(100),
             dst_start_time: 0,
             dst_end: RuleDay::Julian0WithLeap(101),
@@ -1079,5 +1080,11 @@ mod test {
         assert_eq!(days_since_unix_epoch(104, 1, 29), 12477);
         assert_eq!(days_since_unix_epoch(200, 2, 1), 47541);
         assert_eq!(days_since_unix_epoch(1101, 2, 1), 376624);
+    }
+
+    #[test]
+    fn test_date_time_is_sync_and_send() {
+        trait AssertSendSyncStatic: Send + Sync + 'static {}
+        impl AssertSendSyncStatic for DateTime {}
     }
 }

--- a/src/tz_file.rs
+++ b/src/tz_file.rs
@@ -222,7 +222,7 @@ impl<'a> DataBlock<'a> {
             }
 
             let time_zone_designation = match self.time_zone_designations[char_index..].iter().position(|&c| c == b'\0') {
-                Some(position) => str::from_utf8(&self.time_zone_designations[char_index..char_index + position])?.to_owned(),
+                Some(position) => str::from_utf8(&self.time_zone_designations[char_index..char_index + position])?.into(),
                 None => return Err(TzFileError::InvalidTzFile("invalid time zone designation char index")),
             };
 
@@ -364,7 +364,7 @@ mod test {
 
         let time_zone_result = TimeZone {
             transitions: Vec::new(),
-            local_time_types: vec![LocalTimeType { ut_offset: 0, is_dst: false, time_zone_designation: "UTC".to_owned() }],
+            local_time_types: vec![LocalTimeType { ut_offset: 0, is_dst: false, time_zone_designation: "UTC".into() }],
             leap_seconds: vec![
                 LeapSecond { unix_leap_time: 78796800, correction: 1 },
                 LeapSecond { unix_leap_time: 94694401, correction: 2 },
@@ -428,21 +428,21 @@ mod test {
                 Transition { unix_leap_time: -712150200, local_time_type_index: 5 },
             ],
             local_time_types: vec![
-                LocalTimeType { ut_offset: -37886, is_dst: false, time_zone_designation: "LMT".to_owned() },
-                LocalTimeType { ut_offset: -37800, is_dst: false, time_zone_designation: "HST".to_owned() },
-                LocalTimeType { ut_offset: -34200, is_dst: true, time_zone_designation: "HDT".to_owned() },
-                LocalTimeType { ut_offset: -34200, is_dst: true, time_zone_designation: "HWT".to_owned() },
-                LocalTimeType { ut_offset: -34200, is_dst: true, time_zone_designation: "HPT".to_owned() },
-                LocalTimeType { ut_offset: -36000, is_dst: false, time_zone_designation: "HST".to_owned() },
+                LocalTimeType { ut_offset: -37886, is_dst: false, time_zone_designation: "LMT".into() },
+                LocalTimeType { ut_offset: -37800, is_dst: false, time_zone_designation: "HST".into() },
+                LocalTimeType { ut_offset: -34200, is_dst: true, time_zone_designation: "HDT".into() },
+                LocalTimeType { ut_offset: -34200, is_dst: true, time_zone_designation: "HWT".into() },
+                LocalTimeType { ut_offset: -34200, is_dst: true, time_zone_designation: "HPT".into() },
+                LocalTimeType { ut_offset: -36000, is_dst: false, time_zone_designation: "HST".into() },
             ],
             leap_seconds: Vec::new(),
-            extra_rule: Some(TransitionRule::Fixed(LocalTimeType { ut_offset: -36000, is_dst: false, time_zone_designation: "HST".to_owned() })),
+            extra_rule: Some(TransitionRule::Fixed(LocalTimeType { ut_offset: -36000, is_dst: false, time_zone_designation: "HST".into() })),
         };
 
         assert_eq!(time_zone, time_zone_result);
 
-        assert_eq!(*time_zone.find_local_time_type(-1156939200)?, LocalTimeType { ut_offset: -34200, is_dst: true, time_zone_designation: "HDT".to_owned() });
-        assert_eq!(*time_zone.find_local_time_type(1546300800)?, LocalTimeType { ut_offset: -36000, is_dst: false, time_zone_designation: "HST".to_owned() });
+        assert_eq!(*time_zone.find_local_time_type(-1156939200)?, LocalTimeType { ut_offset: -34200, is_dst: true, time_zone_designation: "HDT".into() });
+        assert_eq!(*time_zone.find_local_time_type(1546300800)?, LocalTimeType { ut_offset: -36000, is_dst: false, time_zone_designation: "HST".into() });
 
         Ok(())
     }
@@ -455,11 +455,11 @@ mod test {
 
         let time_zone_result = TimeZone {
             transitions: vec![Transition { unix_leap_time: 2145916800, local_time_type_index: 0 }],
-            local_time_types: vec![LocalTimeType { ut_offset: 7200, is_dst: false, time_zone_designation: "IST".to_owned() }],
+            local_time_types: vec![LocalTimeType { ut_offset: 7200, is_dst: false, time_zone_designation: "IST".into() }],
             leap_seconds: Vec::new(),
             extra_rule: Some(TransitionRule::Alternate {
-                std: LocalTimeType { ut_offset: 7200, is_dst: false, time_zone_designation: "IST".to_owned() },
-                dst: LocalTimeType { ut_offset: 10800, is_dst: true, time_zone_designation: "IDT".to_owned() },
+                std: LocalTimeType { ut_offset: 7200, is_dst: false, time_zone_designation: "IST".into() },
+                dst: LocalTimeType { ut_offset: 10800, is_dst: true, time_zone_designation: "IDT".into() },
                 dst_start: RuleDay::MonthWeekDay { month: 3, week: 4, week_day: 4 },
                 dst_start_time: 93600,
                 dst_end: RuleDay::MonthWeekDay { month: 10, week: 5, week_day: 0 },

--- a/src/tz_string.rs
+++ b/src/tz_string.rs
@@ -224,14 +224,14 @@ fn parse_rule_block(cursor: &mut Cursor, use_string_extensions: bool) -> Result<
 pub(crate) fn parse_posix_tz(tz_string: &[u8], use_string_extensions: bool) -> Result<TransitionRule, TzStringError> {
     let mut cursor = Cursor::new(tz_string);
 
-    let std_time_zone = str::from_utf8(parse_time_zone_designation(&mut cursor)?)?.to_owned();
+    let std_time_zone = str::from_utf8(parse_time_zone_designation(&mut cursor)?)?.into();
     let std_offset = parse_offset(&mut cursor)?;
 
     if cursor.is_empty() {
         return Ok(TransitionRule::Fixed(LocalTimeType { ut_offset: -std_offset, is_dst: false, time_zone_designation: std_time_zone }));
     }
 
-    let dst_time_zone = str::from_utf8(parse_time_zone_designation(&mut cursor)?)?.to_owned();
+    let dst_time_zone = str::from_utf8(parse_time_zone_designation(&mut cursor)?)?.into();
 
     let dst_offset = match cursor.remaining().get(0) {
         Some(&b',') => std_offset - 3600,
@@ -270,7 +270,7 @@ mod test {
         let tz_string = b"HST10";
 
         let transition_rule = parse_posix_tz(tz_string, false)?;
-        let transition_rule_result = TransitionRule::Fixed(LocalTimeType { ut_offset: -36000, is_dst: false, time_zone_designation: "HST".to_owned() });
+        let transition_rule_result = TransitionRule::Fixed(LocalTimeType { ut_offset: -36000, is_dst: false, time_zone_designation: "HST".into() });
 
         assert_eq!(transition_rule, transition_rule_result);
         assert_eq!(transition_rule.find_local_time_type(0)?.ut_offset(), -36000);
@@ -285,8 +285,8 @@ mod test {
         let transition_rule = parse_posix_tz(tz_string, false)?;
 
         let transition_rule_result = TransitionRule::Alternate {
-            std: LocalTimeType { ut_offset: -10800, is_dst: false, time_zone_designation: "-03".to_owned() },
-            dst: LocalTimeType { ut_offset: 10800, is_dst: true, time_zone_designation: "+03".to_owned() },
+            std: LocalTimeType { ut_offset: -10800, is_dst: false, time_zone_designation: "-03".into() },
+            dst: LocalTimeType { ut_offset: 10800, is_dst: true, time_zone_designation: "+03".into() },
             dst_start: RuleDay::Julian1WithoutLeap(1),
             dst_start_time: 7200,
             dst_end: RuleDay::Julian1WithoutLeap(365),
@@ -305,8 +305,8 @@ mod test {
         let transition_rule = parse_posix_tz(tz_string, false)?;
 
         let transition_rule_result = TransitionRule::Alternate {
-            std: LocalTimeType { ut_offset: 43200, is_dst: false, time_zone_designation: "NZST".to_owned() },
-            dst: LocalTimeType { ut_offset: 46800, is_dst: true, time_zone_designation: "NZDT".to_owned() },
+            std: LocalTimeType { ut_offset: 43200, is_dst: false, time_zone_designation: "NZST".into() },
+            dst: LocalTimeType { ut_offset: 46800, is_dst: true, time_zone_designation: "NZDT".into() },
             dst_start: RuleDay::MonthWeekDay { month: 10, week: 1, week_day: 0 },
             dst_start_time: 7200,
             dst_end: RuleDay::MonthWeekDay { month: 3, week: 3, week_day: 0 },
@@ -330,8 +330,8 @@ mod test {
         let transition_rule = parse_posix_tz(tz_string, false)?;
 
         let transition_rule_result = TransitionRule::Alternate {
-            std: LocalTimeType { ut_offset: 3600, is_dst: false, time_zone_designation: "IST".to_owned() },
-            dst: LocalTimeType { ut_offset: 0, is_dst: true, time_zone_designation: "GMT".to_owned() },
+            std: LocalTimeType { ut_offset: 3600, is_dst: false, time_zone_designation: "IST".into() },
+            dst: LocalTimeType { ut_offset: 0, is_dst: true, time_zone_designation: "GMT".into() },
             dst_start: RuleDay::MonthWeekDay { month: 10, week: 5, week_day: 0 },
             dst_start_time: 7200,
             dst_end: RuleDay::MonthWeekDay { month: 3, week: 5, week_day: 0 },
@@ -357,8 +357,8 @@ mod test {
         let transition_rule = parse_posix_tz(tz_string, true)?;
 
         let transition_rule_result = TransitionRule::Alternate {
-            std: LocalTimeType { ut_offset: -10800, is_dst: false, time_zone_designation: "-03".to_owned() },
-            dst: LocalTimeType { ut_offset: -7200, is_dst: true, time_zone_designation: "-02".to_owned() },
+            std: LocalTimeType { ut_offset: -10800, is_dst: false, time_zone_designation: "-03".into() },
+            dst: LocalTimeType { ut_offset: -7200, is_dst: true, time_zone_designation: "-02".into() },
             dst_start: RuleDay::MonthWeekDay { month: 3, week: 5, week_day: 0 },
             dst_start_time: -7200,
             dst_end: RuleDay::MonthWeekDay { month: 10, week: 5, week_day: 0 },
@@ -384,8 +384,8 @@ mod test {
         let transition_rule = parse_posix_tz(tz_string, true)?;
 
         let transition_rule_result = TransitionRule::Alternate {
-            std: LocalTimeType { ut_offset: -18000, is_dst: false, time_zone_designation: "EST".to_owned() },
-            dst: LocalTimeType { ut_offset: -14400, is_dst: true, time_zone_designation: "EDT".to_owned() },
+            std: LocalTimeType { ut_offset: -18000, is_dst: false, time_zone_designation: "EST".into() },
+            dst: LocalTimeType { ut_offset: -14400, is_dst: true, time_zone_designation: "EDT".into() },
             dst_start: RuleDay::Julian0WithLeap(0),
             dst_start_time: 0,
             dst_end: RuleDay::Julian1WithoutLeap(365),


### PR DESCRIPTION
There is no need to clone the string when the data can be shared.