### PR TITLE
Make `const_fn` an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 name = "tz"
 
 [dependencies]
-const_fn = "0.4"
+const_fn = { version = "0.4", optional = true }
 
 [features]
 default = ["const"]
-const = []
+const = ["const_fn"]

--- a/src/timezone/mod.rs
+++ b/src/timezone/mod.rs
@@ -18,8 +18,6 @@ use std::io::{self, Read};
 use std::str;
 use std::time::SystemTime;
 
-use const_fn::const_fn;
-
 /// Transition of a TZif file
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Transition {
@@ -31,20 +29,20 @@ pub struct Transition {
 
 impl Transition {
     /// Construct a TZif file transition
-    #[const_fn(feature = "const")]
-    pub const fn new(unix_leap_time: i64, local_time_type_index: usize) -> Self {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn new(unix_leap_time: i64, local_time_type_index: usize) -> Self {
         Self { unix_leap_time, local_time_type_index }
     }
 
     /// Returns Unix leap time
-    #[const_fn(feature = "const")]
-    pub const fn unix_leap_time(&self) -> i64 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn unix_leap_time(&self) -> i64 {
         self.unix_leap_time
     }
 
     /// Returns local time type index
-    #[const_fn(feature = "const")]
-    pub const fn local_time_type_index(&self) -> usize {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn local_time_type_index(&self) -> usize {
         self.local_time_type_index
     }
 }
@@ -60,20 +58,20 @@ pub struct LeapSecond {
 
 impl LeapSecond {
     /// Construct a TZif file leap second
-    #[const_fn(feature = "const")]
-    pub const fn new(unix_leap_time: i64, correction: i32) -> Self {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn new(unix_leap_time: i64, correction: i32) -> Self {
         Self { unix_leap_time, correction }
     }
 
     /// Returns Unix leap time
-    #[const_fn(feature = "const")]
-    pub const fn unix_leap_time(&self) -> i64 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn unix_leap_time(&self) -> i64 {
         self.unix_leap_time
     }
 
     /// Returns leap second correction
-    #[const_fn(feature = "const")]
-    pub const fn correction(&self) -> i32 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn correction(&self) -> i32 {
         self.correction
     }
 }
@@ -87,8 +85,8 @@ struct TzAsciiStr {
 
 impl TzAsciiStr {
     /// Construct a time zone designation string
-    #[const_fn(feature = "const")]
-    const fn new(input: &[u8]) -> Result<Self, LocalTimeTypeError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn new(input: &[u8]) -> Result<Self, LocalTimeTypeError> {
         let len = input.len();
 
         if !(3 <= len && len <= 7) {
@@ -115,8 +113,8 @@ impl TzAsciiStr {
     }
 
     /// Returns time zone designation as a byte slice
-    #[const_fn(feature = "const")]
-    const fn as_bytes(&self) -> &[u8] {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn as_bytes(&self) -> &[u8] {
         match &self.bytes {
             [3, head @ .., _, _, _, _] => head,
             [4, head @ .., _, _, _] => head,
@@ -128,15 +126,15 @@ impl TzAsciiStr {
     }
 
     /// Returns time zone designation as a string
-    #[const_fn(feature = "const")]
-    const fn as_str(&self) -> &str {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn as_str(&self) -> &str {
         // SAFETY: ASCII is valid UTF-8
         unsafe { str::from_utf8_unchecked(self.as_bytes()) }
     }
 
     /// Check if two time zone designations are equal
-    #[const_fn(feature = "const")]
-    const fn equal(&self, other: &Self) -> bool {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn equal(&self, other: &Self) -> bool {
         u64::from_ne_bytes(self.bytes) == u64::from_ne_bytes(other.bytes)
     }
 }
@@ -160,8 +158,8 @@ pub struct LocalTimeType {
 
 impl LocalTimeType {
     /// Construct a local time type
-    #[const_fn(feature = "const")]
-    pub const fn new(ut_offset: i32, is_dst: bool, time_zone_designation: Option<&[u8]>) -> Result<Self, LocalTimeTypeError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn new(ut_offset: i32, is_dst: bool, time_zone_designation: Option<&[u8]>) -> Result<Self, LocalTimeTypeError> {
         if ut_offset == i32::MIN {
             return Err(LocalTimeTypeError("invalid UTC offset"));
         }
@@ -183,8 +181,8 @@ impl LocalTimeType {
     }
 
     /// Construct a local time type with the specified UTC offset in seconds
-    #[const_fn(feature = "const")]
-    pub const fn with_ut_offset(ut_offset: i32) -> Result<Self, LocalTimeTypeError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn with_ut_offset(ut_offset: i32) -> Result<Self, LocalTimeTypeError> {
         if ut_offset == i32::MIN {
             return Err(LocalTimeTypeError("invalid UTC offset"));
         }
@@ -193,20 +191,20 @@ impl LocalTimeType {
     }
 
     /// Returns offset from UTC in seconds
-    #[const_fn(feature = "const")]
-    pub const fn ut_offset(&self) -> i32 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn ut_offset(&self) -> i32 {
         self.ut_offset
     }
 
     /// Returns daylight saving time indicator
-    #[const_fn(feature = "const")]
-    pub const fn is_dst(&self) -> bool {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn is_dst(&self) -> bool {
         self.is_dst
     }
 
     /// Returns time zone designation
-    #[const_fn(feature = "const")]
-    pub const fn time_zone_designation(&self) -> &str {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn time_zone_designation(&self) -> &str {
         match &self.time_zone_designation {
             Some(s) => s.as_str(),
             None => "",
@@ -214,8 +212,8 @@ impl LocalTimeType {
     }
 
     /// Check if two local time types are equal
-    #[const_fn(feature = "const")]
-    const fn equal(&self, other: &Self) -> bool {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn equal(&self, other: &Self) -> bool {
         self.ut_offset == other.ut_offset
             && self.is_dst == other.is_dst
             && match (&self.time_zone_designation, &other.time_zone_designation) {
@@ -254,8 +252,8 @@ pub struct TimeZoneRef<'a> {
 
 impl<'a> TimeZoneRef<'a> {
     /// Construct a time zone reference
-    #[const_fn(feature = "const")]
-    pub const fn new(
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn new(
         transitions: &'a [Transition],
         local_time_types: &'a [LocalTimeType],
         leap_seconds: &'a [LeapSecond],
@@ -271,39 +269,39 @@ impl<'a> TimeZoneRef<'a> {
     }
 
     /// Construct the time zone reference associated to UTC
-    #[const_fn(feature = "const")]
-    pub const fn utc() -> Self {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn utc() -> Self {
         const UTC: LocalTimeType = LocalTimeType::utc();
         Self { transitions: &[], local_time_types: &[UTC], leap_seconds: &[], extra_rule: &None }
     }
 
     /// Returns list of transitions
-    #[const_fn(feature = "const")]
-    pub const fn transitions(&self) -> &'a [Transition] {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn transitions(&self) -> &'a [Transition] {
         self.transitions
     }
 
     /// Returns list of local time types
-    #[const_fn(feature = "const")]
-    pub const fn local_time_types(&self) -> &'a [LocalTimeType] {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn local_time_types(&self) -> &'a [LocalTimeType] {
         self.local_time_types
     }
 
     /// Returns list of leap seconds
-    #[const_fn(feature = "const")]
-    pub const fn leap_seconds(&self) -> &'a [LeapSecond] {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn leap_seconds(&self) -> &'a [LeapSecond] {
         self.leap_seconds
     }
 
     /// Returns extra transition rule applicable after the last transition
-    #[const_fn(feature = "const")]
-    pub const fn extra_rule(&self) -> &'a Option<TransitionRule> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn extra_rule(&self) -> &'a Option<TransitionRule> {
         self.extra_rule
     }
 
     /// Find the local time type associated to the time zone at the specified Unix time in seconds
-    #[const_fn(feature = "const")]
-    pub const fn find_local_time_type(&self, unix_time: i64) -> Result<&'a LocalTimeType, FindLocalTimeTypeError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn find_local_time_type(&self, unix_time: i64) -> Result<&'a LocalTimeType, FindLocalTimeTypeError> {
         let extra_rule = match self.transitions.last() {
             None => match self.extra_rule {
                 Some(extra_rule) => extra_rule,
@@ -339,8 +337,8 @@ impl<'a> TimeZoneRef<'a> {
     }
 
     /// Construct a reference to a time zone
-    #[const_fn(feature = "const")]
-    const fn new_unchecked(
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn new_unchecked(
         transitions: &'a [Transition],
         local_time_types: &'a [LocalTimeType],
         leap_seconds: &'a [LeapSecond],
@@ -350,8 +348,8 @@ impl<'a> TimeZoneRef<'a> {
     }
 
     /// Check time zone inputs
-    #[const_fn(feature = "const")]
-    const fn check_inputs(&self) -> Result<(), TimeZoneError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn check_inputs(&self) -> Result<(), TimeZoneError> {
         use crate::constants::*;
 
         // Check local time types
@@ -420,8 +418,8 @@ impl<'a> TimeZoneRef<'a> {
     }
 
     /// Convert Unix time to Unix leap time, from the list of leap seconds in a time zone
-    #[const_fn(feature = "const")]
-    pub(crate) const fn unix_time_to_unix_leap_time(&self, unix_time: i64) -> Result<i64, OutOfRangeError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub(crate) fn unix_time_to_unix_leap_time(&self, unix_time: i64) -> Result<i64, OutOfRangeError> {
         let mut unix_leap_time = unix_time;
 
         let mut i = 0;
@@ -444,8 +442,8 @@ impl<'a> TimeZoneRef<'a> {
     }
 
     /// Convert Unix leap time to Unix time, from the list of leap seconds in a time zone
-    #[const_fn(feature = "const")]
-    pub(crate) const fn unix_leap_time_to_unix_time(&self, unix_leap_time: i64) -> Result<i64, OutOfRangeError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub(crate) fn unix_leap_time_to_unix_time(&self, unix_leap_time: i64) -> Result<i64, OutOfRangeError> {
         if unix_leap_time == i64::MIN {
             return Err(OutOfRangeError("out of range operation"));
         }

--- a/src/timezone/rule.rs
+++ b/src/timezone/rule.rs
@@ -35,8 +35,8 @@ pub struct Julian1WithoutLeap(u16);
 
 impl Julian1WithoutLeap {
     /// Construct a transition rule day represented by a Julian day in `[1, 365]`, without taking occasional February 29th into account, which is not referenceable
-    #[const_fn(feature = "const")]
-    pub const fn new(julian_day_1: u16) -> Result<Self, TransitionRuleError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn new(julian_day_1: u16) -> Result<Self, TransitionRuleError> {
         if !(1 <= julian_day_1 && julian_day_1 <= 365) {
             return Err(TransitionRuleError("invalid rule day julian day"));
         }
@@ -45,8 +45,8 @@ impl Julian1WithoutLeap {
     }
 
     /// Returns inner value
-    #[const_fn(feature = "const")]
-    pub const fn get(&self) -> u16 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn get(&self) -> u16 {
         self.0
     }
 
@@ -57,8 +57,8 @@ impl Julian1WithoutLeap {
     /// * `month`: Month in `[1, 12]`
     /// * `month_day`: Day of the month in `[1, 31]`
     ///
-    #[const_fn(feature = "const")]
-    const fn transition_date(&self) -> (usize, i64) {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn transition_date(&self) -> (usize, i64) {
         let year_day = self.0 as i64;
 
         let month = match binary_search_i64(&CUMUL_DAYS_IN_MONTHS_NORMAL_YEAR, year_day - 1) {
@@ -72,8 +72,8 @@ impl Julian1WithoutLeap {
     }
 
     /// Compute the informations needed for checking DST transition rules consistency
-    #[const_fn(feature = "const")]
-    const fn compute_check_infos(&self, utc_day_time: i64) -> JulianDayCheckInfos {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn compute_check_infos(&self, utc_day_time: i64) -> JulianDayCheckInfos {
         let start_normal_year_offset = (self.0 as i64 - 1) * SECONDS_PER_DAY + utc_day_time;
         let start_leap_year_offset = if self.0 <= 59 { start_normal_year_offset } else { start_normal_year_offset + SECONDS_PER_DAY };
 
@@ -92,8 +92,8 @@ pub struct Julian0WithLeap(u16);
 
 impl Julian0WithLeap {
     /// Construct a transition rule day represented by a zero-based Julian day in `[0, 365]`, taking occasional February 29th into account and allowing December 32nd
-    #[const_fn(feature = "const")]
-    pub const fn new(julian_day_0: u16) -> Result<Self, TransitionRuleError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn new(julian_day_0: u16) -> Result<Self, TransitionRuleError> {
         if julian_day_0 > 365 {
             return Err(TransitionRuleError("invalid rule day julian day"));
         }
@@ -102,8 +102,8 @@ impl Julian0WithLeap {
     }
 
     /// Returns inner value
-    #[const_fn(feature = "const")]
-    pub const fn get(&self) -> u16 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn get(&self) -> u16 {
         self.0
     }
 
@@ -116,8 +116,8 @@ impl Julian0WithLeap {
     /// * `month`: Month in `[1, 12]`
     /// * `month_day`: Day of the month in `[1, 32]`
     ///
-    #[const_fn(feature = "const")]
-    const fn transition_date(&self, leap_year: bool) -> (usize, i64) {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn transition_date(&self, leap_year: bool) -> (usize, i64) {
         let cumul_day_in_months = if leap_year { &CUMUL_DAYS_IN_MONTHS_LEAP_YEAR } else { &CUMUL_DAYS_IN_MONTHS_NORMAL_YEAR };
 
         let year_day = self.0 as i64;
@@ -133,8 +133,8 @@ impl Julian0WithLeap {
     }
 
     /// Compute the informations needed for checking DST transition rules consistency
-    #[const_fn(feature = "const")]
-    const fn compute_check_infos(&self, utc_day_time: i64) -> JulianDayCheckInfos {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn compute_check_infos(&self, utc_day_time: i64) -> JulianDayCheckInfos {
         let start_year_offset = self.0 as i64 * SECONDS_PER_DAY + utc_day_time;
 
         JulianDayCheckInfos {
@@ -159,8 +159,8 @@ pub struct MonthWeekDay {
 
 impl MonthWeekDay {
     /// Construct a transition rule day represented by a month, a month week and a week day
-    #[const_fn(feature = "const")]
-    pub const fn new(month: u8, week: u8, week_day: u8) -> Result<Self, TransitionRuleError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn new(month: u8, week: u8, week_day: u8) -> Result<Self, TransitionRuleError> {
         if !(1 <= month && month <= 12) {
             return Err(TransitionRuleError("invalid rule day month"));
         }
@@ -177,20 +177,20 @@ impl MonthWeekDay {
     }
 
     /// Returns month in `[1, 12]`
-    #[const_fn(feature = "const")]
-    pub const fn month(&self) -> u8 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn month(&self) -> u8 {
         self.month
     }
 
     /// Returns week of the month in `[1, 5]`, with `5` representing the last week of the month
-    #[const_fn(feature = "const")]
-    pub const fn week(&self) -> u8 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn week(&self) -> u8 {
         self.week
     }
 
     /// Returns day of the week in `[0, 6]` from Sunday
-    #[const_fn(feature = "const")]
-    pub const fn week_day(&self) -> u8 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn week_day(&self) -> u8 {
         self.week_day
     }
 
@@ -201,8 +201,8 @@ impl MonthWeekDay {
     /// * `month`: Month in `[1, 12]`
     /// * `month_day`: Day of the month in `[1, 31]`
     ///
-    #[const_fn(feature = "const")]
-    const fn transition_date(&self, year: i32) -> (usize, i64) {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn transition_date(&self, year: i32) -> (usize, i64) {
         let month = self.month as usize;
         let week = self.week as i64;
         let week_day = self.week_day as i64;
@@ -224,8 +224,8 @@ impl MonthWeekDay {
     }
 
     /// Compute the informations needed for checking DST transition rules consistency
-    #[const_fn(feature = "const")]
-    const fn compute_check_infos(&self, utc_day_time: i64) -> MonthWeekDayCheckInfos {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn compute_check_infos(&self, utc_day_time: i64) -> MonthWeekDayCheckInfos {
         let month = self.month as usize;
         let week = self.week as i64;
 
@@ -287,8 +287,8 @@ impl RuleDay {
     /// * `month`: Month in `[1, 12]`
     /// * `month_day`: Day of the month in `[1, 32]`
     ///
-    #[const_fn(feature = "const")]
-    const fn transition_date(&self, year: i32) -> (usize, i64) {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn transition_date(&self, year: i32) -> (usize, i64) {
         match self {
             Self::Julian1WithoutLeap(rule_day) => rule_day.transition_date(),
             Self::Julian0WithLeap(rule_day) => rule_day.transition_date(is_leap_year(year)),
@@ -297,8 +297,8 @@ impl RuleDay {
     }
 
     /// Returns the UTC Unix time in seconds associated to the transition date for the provided year
-    #[const_fn(feature = "const")]
-    pub(crate) const fn unix_time(&self, year: i32, day_time_in_utc: i64) -> i64 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub(crate) fn unix_time(&self, year: i32, day_time_in_utc: i64) -> i64 {
         let (month, month_day) = self.transition_date(year);
         days_since_unix_epoch(year, month, month_day) * SECONDS_PER_DAY + day_time_in_utc
     }
@@ -323,8 +323,8 @@ pub struct AlternateTime {
 
 impl AlternateTime {
     /// Construct a transition rule representing alternate local time types
-    #[const_fn(feature = "const")]
-    pub const fn new(
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn new(
         std: LocalTimeType,
         dst: LocalTimeType,
         dst_start: RuleDay,
@@ -358,44 +358,44 @@ impl AlternateTime {
     }
 
     /// Returns local time type for standard time
-    #[const_fn(feature = "const")]
-    pub const fn std(&self) -> &LocalTimeType {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn std(&self) -> &LocalTimeType {
         &self.std
     }
 
     /// Returns local time type for Daylight Saving Time
-    #[const_fn(feature = "const")]
-    pub const fn dst(&self) -> &LocalTimeType {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn dst(&self) -> &LocalTimeType {
         &self.dst
     }
 
     /// Returns start day of Daylight Saving Time
-    #[const_fn(feature = "const")]
-    pub const fn dst_start(&self) -> &RuleDay {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn dst_start(&self) -> &RuleDay {
         &self.dst_start
     }
 
     /// Returns local start day time of Daylight Saving Time, in seconds
-    #[const_fn(feature = "const")]
-    pub const fn dst_start_time(&self) -> i32 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn dst_start_time(&self) -> i32 {
         self.dst_start_time
     }
 
     /// Returns end day of Daylight Saving Time
-    #[const_fn(feature = "const")]
-    pub const fn dst_end(&self) -> &RuleDay {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn dst_end(&self) -> &RuleDay {
         &self.dst_end
     }
 
     /// Returns local end day time of Daylight Saving Time, in seconds
-    #[const_fn(feature = "const")]
-    pub const fn dst_end_time(&self) -> i32 {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub fn dst_end_time(&self) -> i32 {
         self.dst_end_time
     }
 
     /// Find the local time type associated to the alternate transition rule at the specified Unix time in seconds
-    #[const_fn(feature = "const")]
-    const fn find_local_time_type(&self, unix_time: i64) -> Result<&LocalTimeType, OutOfRangeError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    fn find_local_time_type(&self, unix_time: i64) -> Result<&LocalTimeType, OutOfRangeError> {
         // Overflow is not possible
         let dst_start_time_in_utc = self.dst_start_time as i64 - self.std.ut_offset as i64;
         let dst_end_time_in_utc = self.dst_end_time as i64 - self.dst.ut_offset as i64;
@@ -480,8 +480,8 @@ pub enum TransitionRule {
 
 impl TransitionRule {
     /// Find the local time type associated to the transition rule at the specified Unix time in seconds
-    #[const_fn(feature = "const")]
-    pub(super) const fn find_local_time_type(&self, unix_time: i64) -> Result<&LocalTimeType, OutOfRangeError> {
+    #[cfg_attr(feature = "const", const_fn::const_fn)]
+    pub(super) fn find_local_time_type(&self, unix_time: i64) -> Result<&LocalTimeType, OutOfRangeError> {
         match self {
             Self::Fixed(local_time_type) => Ok(local_time_type),
             Self::Alternate(alternate_time) => alternate_time.find_local_time_type(unix_time),
@@ -493,8 +493,8 @@ impl TransitionRule {
 ///
 /// This prevents from having an additional transition at the year boundary, when the order of DST start and end time is different on consecutive years.
 ///
-#[const_fn(feature = "const")]
-const fn check_dst_transition_rules_consistency(
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+fn check_dst_transition_rules_consistency(
     std: &LocalTimeType,
     dst: &LocalTimeType,
     dst_start: RuleDay,
@@ -538,8 +538,8 @@ const fn check_dst_transition_rules_consistency(
 }
 
 /// Check DST transition rules consistency for two Julian days
-#[const_fn(feature = "const")]
-const fn check_two_julian_days(check_infos_1: JulianDayCheckInfos, check_infos_2: JulianDayCheckInfos) -> bool {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+fn check_two_julian_days(check_infos_1: JulianDayCheckInfos, check_infos_2: JulianDayCheckInfos) -> bool {
     // Check in same year
     let (before, after) = if check_infos_1.start_normal_year_offset <= check_infos_2.start_normal_year_offset
         && check_infos_1.start_leap_year_offset <= check_infos_2.start_leap_year_offset
@@ -572,8 +572,8 @@ const fn check_two_julian_days(check_infos_1: JulianDayCheckInfos, check_infos_2
 }
 
 /// Check DST transition rules consistency for a Julian day and a day represented by a month, a month week and a week day
-#[const_fn(feature = "const")]
-const fn check_month_week_day_and_julian_day(check_infos_1: MonthWeekDayCheckInfos, check_infos_2: JulianDayCheckInfos) -> bool {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+fn check_month_week_day_and_julian_day(check_infos_1: MonthWeekDayCheckInfos, check_infos_2: JulianDayCheckInfos) -> bool {
     // Check in same year, then in consecutive years
     if check_infos_2.start_normal_year_offset <= check_infos_1.start_normal_year_offset_range.0
         && check_infos_2.start_leap_year_offset <= check_infos_1.start_leap_year_offset_range.0
@@ -623,8 +623,8 @@ const fn check_month_week_day_and_julian_day(check_infos_1: MonthWeekDayCheckInf
 }
 
 /// Check DST transition rules consistency for two days represented by a month, a month week and a week day
-#[const_fn(feature = "const")]
-const fn check_two_month_week_days(month_week_day_1: MonthWeekDay, utc_day_time_1: i64, month_week_day_2: MonthWeekDay, utc_day_time_2: i64) -> bool {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+fn check_two_month_week_days(month_week_day_1: MonthWeekDay, utc_day_time_1: i64, month_week_day_2: MonthWeekDay, utc_day_time_2: i64) -> bool {
     // Sort rule days
     let (month_week_day_before, utc_day_time_before, month_week_day_after, utc_day_time_after) = {
         let rem = (month_week_day_2.month as i64 - month_week_day_1.month as i64).rem_euclid(MONTHS_PER_YEAR);

--- a/src/utils/const_fns.rs
+++ b/src/utils/const_fns.rs
@@ -5,11 +5,9 @@ use crate::timezone::{LeapSecond, Transition};
 
 use std::cmp::Ordering;
 
-use const_fn::const_fn;
-
 /// Compare two values
-#[const_fn(feature = "const")]
-pub const fn cmp(a: i64, b: i64) -> Ordering {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+pub fn cmp(a: i64, b: i64) -> Ordering {
     if a < b {
         Ordering::Less
     } else if a == b {
@@ -20,8 +18,8 @@ pub const fn cmp(a: i64, b: i64) -> Ordering {
 }
 
 /// Returns the minimum of two values
-#[const_fn(feature = "const")]
-pub const fn min(a: i64, b: i64) -> i64 {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+pub fn min(a: i64, b: i64) -> i64 {
     match cmp(a, b) {
         Ordering::Less | Ordering::Equal => a,
         Ordering::Greater => b,
@@ -43,14 +41,14 @@ macro_rules! impl_try_into_integer {
 }
 
 /// Convert a `i64` value to a `i32` value
-#[const_fn(feature = "const")]
-pub const fn try_into_i32(value: i64) -> Result<i32, OutOfRangeError> {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+pub fn try_into_i32(value: i64) -> Result<i32, OutOfRangeError> {
     impl_try_into_integer!(i64, i32, value)
 }
 
 /// Convert a `i128` value to a `i64` value
-#[const_fn(feature = "const")]
-pub const fn try_into_i64(value: i128) -> Result<i64, OutOfRangeError> {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+pub fn try_into_i64(value: i128) -> Result<i64, OutOfRangeError> {
     impl_try_into_integer!(i128, i64, value)
 }
 
@@ -79,25 +77,25 @@ macro_rules! impl_binary_search {
 }
 
 /// Copy the input value
-#[const_fn(feature = "const")]
-const fn copied(x: &i64) -> i64 {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+fn copied(x: &i64) -> i64 {
     *x
 }
 
 /// Binary searches a sorted `i64` slice for the given element
-#[const_fn(feature = "const")]
-pub const fn binary_search_i64(slice: &[i64], x: i64) -> Result<usize, usize> {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+pub fn binary_search_i64(slice: &[i64], x: i64) -> Result<usize, usize> {
     impl_binary_search!(slice, copied, x)
 }
 
 /// Binary searches a sorted `Transition` slice for the given element
-#[const_fn(feature = "const")]
-pub const fn binary_search_transitions(slice: &[Transition], x: i64) -> Result<usize, usize> {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+pub fn binary_search_transitions(slice: &[Transition], x: i64) -> Result<usize, usize> {
     impl_binary_search!(slice, Transition::unix_leap_time, x)
 }
 
 /// Binary searches a sorted `LeapSecond` slice for the given element
-#[const_fn(feature = "const")]
-pub const fn binary_search_leap_seconds(slice: &[LeapSecond], x: i64) -> Result<usize, usize> {
+#[cfg_attr(feature = "const", const_fn::const_fn)]
+pub fn binary_search_leap_seconds(slice: &[LeapSecond], x: i64) -> Result<usize, usize> {
     impl_binary_search!(slice, LeapSecond::unix_leap_time, x)
 }


### PR DESCRIPTION
The docs for the latest `const_fn` have a snippet on how to use the
attribute macro as an optional dependency [0].

[0] https://docs.rs/const_fn/0.4.9/const_fn/#use-this-crate-as-an-optional-dependency

These two attributes have the same effect:

    #[const_fn(feature = "const")]
    pub const fn whatever() {}

    #[cfg_attr(feature = "const", const_fn::const_fn)]
    pub fn whatever() {}

But the `cfg_attr` version only requires `const_fn` crate to be a
dependency when the `const` feature is enabled.

This enables building `tz-rs` without any dependencies and without any
proc macros.

This was mostly an automated refactor with `sed`. I took a peek at the
docs with `cargo doc --open` to see if things looked mostly the same
with default features.