### PR TITLE
Update `const_fn` to 0.4.4 minimum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 name = "tz"
 
 [dependencies]
-const_fn = { version = "0.4", optional = true }
+const_fn = { version = "0.4.4", optional = true }
 
 [features]
 default = ["const"]


### PR DESCRIPTION
`const_fn` attribute with no arguments only added since 0.4.4: https://github.com/taiki-e/const_fn/blob/main/CHANGELOG.md#044---2020-11-02

This caused issues when using `-minimal-versions` as Cargo would attempt to use 0.4.2 which did not have this functionality

To replicate issue:
```
$ cargo generate-lockfile -Zminimal-versions
$ cargo check
...
error: expected one of: `nightly`, `cfg`, `feature`, string literal
 --> src/utils/const_fns.rs:9:31
  |
9 | #[cfg_attr(feature = "const", const_fn::const_fn)]
  |                               ^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the attribute macro `const_fn::const_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
...
```

With the fix in this PR:
```
$ cargo generate-lockfile -Zminimal-versions
    Updating crates.io index
$ cargo check                               
   Compiling const_fn v0.4.4
    Checking tz-rs v0.6.9 (/home/ben/Workspace/tz-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 0.99s
```