### PR TITLE
Allow one- and two-character timezone aliases

### DIFF
--- a/src/timezone/mod.rs
+++ b/src/timezone/mod.rs
@@ -91,7 +91,7 @@ impl TzAsciiStr {
     const fn new(input: &[u8]) -> Result<Self, LocalTimeTypeError> {
         let len = input.len();
 
-        if !(3 <= len && len <= 7) {
+        if len < 1 || len > 7 {
             return Err(LocalTimeTypeError::InvalidTimeZoneDesignationLength);
         }
 
@@ -118,6 +118,8 @@ impl TzAsciiStr {
     #[inline]
     const fn as_bytes(&self) -> &[u8] {
         match &self.bytes {
+            [1, head @ .., _, _, _, _, _, _] => head,
+            [2, head @ .., _, _, _, _, _] => head,
             [3, head @ .., _, _, _, _] => head,
             [4, head @ .., _, _, _] => head,
             [5, head @ .., _, _] => head,
@@ -628,8 +630,8 @@ mod tests {
     #[test]
     fn test_tz_ascii_str() -> Result<(), TzError> {
         assert!(matches!(TzAsciiStr::new(b""), Err(LocalTimeTypeError::InvalidTimeZoneDesignationLength)));
-        assert!(matches!(TzAsciiStr::new(b"1"), Err(LocalTimeTypeError::InvalidTimeZoneDesignationLength)));
-        assert!(matches!(TzAsciiStr::new(b"12"), Err(LocalTimeTypeError::InvalidTimeZoneDesignationLength)));
+        assert_eq!(TzAsciiStr::new(b"1")?.as_bytes(), b"1");
+        assert_eq!(TzAsciiStr::new(b"12")?.as_bytes(), b"12");
         assert_eq!(TzAsciiStr::new(b"123")?.as_bytes(), b"123");
         assert_eq!(TzAsciiStr::new(b"1234")?.as_bytes(), b"1234");
         assert_eq!(TzAsciiStr::new(b"12345")?.as_bytes(), b"12345");


### PR DESCRIPTION
This allows e.g. "Z" to be used as a timezone alias.

I looked through the history to see why short aliases were disallowed and ended up at “Initial commit” so if there is some reason to not do this, let me know what that is. I needed shorter aliases when writing something to be compatible with [timelib](https://github.com/derickr/timelib/) because that library supports all of the single-letter ACP 121 time zone aliases and so I also needed to support them.